### PR TITLE
Hide div.custom-page-title

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -268,7 +268,8 @@
 }
 
 .custom-page-title {
-  font-size: calc(var(--base-font-size) * var(--h1-scale)) !important
+  font-size: calc(var(--base-font-size) * var(--h1-scale)) !important;
+  display: none !important;
 }
 
 .post-content {


### PR DESCRIPTION
This PR hides the div.custom-page-title element by setting its display property to none. This allows for easy re-enabling later by simply removing the  rule from .