### PR TITLE
Add source code icon button to site header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,6 +7,13 @@
     <!-- <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a> -->
     <!-- <a class="site-title" rel="author" style="text-decoration: none;">{{ site.title | escape }}</a> -->
 
+    <a class="source-code-link" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io" target="_blank" rel="noopener" title="View source on GitHub">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="16 18 22 12 16 6"></polyline>
+        <polyline points="8 6 2 12 8 18"></polyline>
+      </svg>
+    </a>
+
     {%- if titles_size > 0 -%}
       <nav class="site-nav">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,2 +1,29 @@
 // Placeholder to allow defining custom styles that override everything else.
 // (Use `_sass/minima/custom-variables.scss` to override variable defaults)
+
+// Source code icon button — top-right of site header
+.source-code-link {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  color: $brand-color;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+  line-height: 1;
+  padding: 4px;
+
+  &:hover {
+    opacity: 1;
+    color: $brand-color-light;
+  }
+
+  svg {
+    display: block;
+  }
+
+  // On mobile, shift left to avoid collision with hamburger menu
+  @include media-query($on-palm) {
+    right: 50px;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `</>` source code icon button to the top-right of every page that links to the GitHub repository.

## Design Decisions

**Placement — Site header (`header.html`)**
The icon lives in the site header partial, which is included by `base.html`. Since every layout (`page`, `post`, `wiki_page`, etc.) extends `base.html`, this guarantees the icon appears on every page without touching individual layouts.

**Icon — Inline SVG code brackets (`<>`) instead of GitHub Octicon**
The footer already uses the GitHub Octicon for the social link. Using a distinct "code brackets" icon (`<>`) communicates "view source" rather than "visit GitHub profile," avoiding visual redundancy while keeping the intent clear.

**Positioning — Absolute within the header wrapper**
The `.site-header .wrapper` already has `position: relative`, so the icon is absolutely positioned top-right within it. This keeps it visually anchored to the header bar without interfering with the nav layout or requiring changes to the existing flexbox/float structure.

**Styling — Subtle by default, visible on hover**
The icon starts at 60% opacity with the theme brand color, fading to full opacity on hover. This keeps it unobtrusive — it is a utility link, not primary navigation — while remaining discoverable.

**Mobile — Shifted left to avoid hamburger collision**
On small screens, the hamburger menu icon sits at the far right. A media query shifts the source icon left by 50px to prevent overlap.

**Dynamic repo URL**
The link uses `site.github_username` from `_config.yml` rather than a hardcoded URL, so it stays correct if the username ever changes.

## Files Changed
- `_includes/header.html` — added the icon link element
- `_sass/minima/custom-styles.scss` — added `.source-code-link` styles