### PR TITLE
Hide Kyle Woody page from notes listing

### DIFF
--- a/_wiki/kyle_woody.md
+++ b/_wiki/kyle_woody.md
@@ -7,7 +7,7 @@ author:
 - Blake Edwards
 tags: [people, mit, aeroastro]
 permalink: /wiki/kyle-woody
-show_on_wiki: true
+show_on_wiki: false
 show_on_secret_wiki: false
 ---
 


### PR DESCRIPTION
Sets show_on_wiki: false on the Kyle Woody wiki page. The page remains accessible at /wiki/kyle-woody but is no longer listed on the notes page.