### PR TITLE
Remove publications from nav bar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,6 @@ collections:
 # Navigation
 header_pages:
   - notes.md
-  - publications.md
   - about.md
   - contact.md
 


### PR DESCRIPTION
Removes publications.md from header_pages in _config.yml.