### PR TITLE
Fix source code button positioning

### DIFF
--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,17 +1,15 @@
 // Placeholder to allow defining custom styles that override everything else.
 // (Use `_sass/minima/custom-variables.scss` to override variable defaults)
 
-// Source code icon button — top-left on desktop, top-right on mobile
+// Source code icon button — floated left in header like site-title
 .source-code-link {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
+  float: left;
+  margin-bottom: 0;
   color: $brand-color;
   opacity: 0.6;
   transition: opacity 0.2s ease;
-  line-height: 1;
-  padding: 4px;
+  display: flex;
+  align-items: center;
 
   &:hover {
     opacity: 1;
@@ -20,11 +18,5 @@
 
   svg {
     display: block;
-  }
-
-  // On mobile, move to top-right and avoid hamburger menu collision
-  @include media-query($on-palm) {
-    left: auto;
-    right: 50px;
   }
 }


### PR DESCRIPTION
Replaces absolute positioning with float:left, matching the site-title layout pattern. The icon now sits naturally in the header flow on the left side of the bar, vertically centered by the header line-height — the same position a site-title would occupy, opposite the nav links on the right.