### PR TITLE
Link source code button to current page source

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
     <!-- <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a> -->
     <!-- <a class="site-title" rel="author" style="text-decoration: none;">{{ site.title | escape }}</a> -->
 
-    <a class="source-code-link" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io" target="_blank" rel="noopener" title="View source on GitHub">
+    <a class="source-code-link" href="https://github.com/{{ site.github_username }}/{{ site.github_username }}.github.io/blob/master/{{ page.path }}" target="_blank" rel="noopener" title="View source on GitHub">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="16 18 22 12 16 6"></polyline>
         <polyline points="8 6 2 12 8 18"></polyline>


### PR DESCRIPTION
Uses Jekyll's page.path to construct a direct link to the source file on the master branch for whatever page the user is viewing. e.g. visiting /about/ links to blob/master/about.md.